### PR TITLE
Use X-Plane 12's new -ele Earth Orbit Textures.

### DIFF
--- a/src/terr.c
+++ b/src/terr.c
@@ -568,7 +568,7 @@ load_earth_orbit_tex(dem_tile_t *tile, double load_res)
 			int png_y_hi = clamp(ceil(png_y), 0, png_height - 1);
 			double x_fract = png_x - png_x_lo;
 			double y_fract = png_y - png_y_lo;
-			double elev;
+			double raw_val;
 
 			/* If the elev file was used or not. */
 			if (ele_file) {
@@ -583,10 +583,8 @@ load_earth_orbit_tex(dem_tile_t *tile, double load_res)
 					(png_x_lo + png_y_hi * png_width) + 1];
 				uint8_t lr = png_pixels[sizeof(uint32_t) *
 					(png_x_hi + png_y_hi * png_width) + 1];
-				double raw_val = wavg(wavg(ul, ur, x_fract),
+				raw_val = wavg(wavg(ul, ur, x_fract),
 					wavg(ll, lr, x_fract), y_fract);
-				elev = fx_lin(raw_val, 0, EOT_ELEV_MAX,
-					255, EOT_ELEV_MIN);
 			} else {
 				uint8_t ul = png_pixels[sizeof(uint32_t) *
 					(png_x_lo + png_y_lo * png_width) + 3];
@@ -596,12 +594,12 @@ load_earth_orbit_tex(dem_tile_t *tile, double load_res)
 					(png_x_lo + png_y_hi * png_width) + 3];
 				uint8_t lr = png_pixels[sizeof(uint32_t) *
 					(png_x_hi + png_y_hi * png_width) + 3];
-				double raw_val = wavg(wavg(ul, ur, x_fract),
+				raw_val = wavg(wavg(ul, ur, x_fract),
 					wavg(ll, lr, x_fract), y_fract);
-				elev = fx_lin(raw_val, 0, EOT_ELEV_MAX,
-					255, EOT_ELEV_MIN);
 			}
 
+			double elev = fx_lin(raw_val, 0, EOT_ELEV_MAX,
+				255, EOT_ELEV_MIN);
 			pixels[x + (pix_height - y - 1) * pix_width] =
 			    ELEV_WRITE(elev);
 		}

--- a/src/terr.c
+++ b/src/terr.c
@@ -512,14 +512,29 @@ load_earth_orbit_tex(dem_tile_t *tile, double load_res)
 	uint8_t *png_pixels;
 	char *path;
 	char filename[32];
+	bool ele_file = true;
 
-	snprintf(filename, sizeof (filename), "%+03.0f%+04.0f-nrm.png",
+	/* Try X-Plane 12's -ele file first. */
+	snprintf(filename, sizeof (filename), "%+03.0f%+04.0f-ele.png",
 	    floor(tile->lat / 10.0) * 10, floor(tile->lon / 10.0) * 10);
 	path = mkpathname(get_xpdir(), "Resources", "bitmaps",
 	    "Earth Orbit Textures", filename, NULL);
 	png_pixels = png_load_from_file_rgba_auto(path,
 	    &png_width, &png_height, &color_type, &bit_depth);
 	lacf_free(path);
+
+	if (png_pixels == NULL) {
+		/* If loading that file didn't work, try the old way. */
+		ele_file = false;
+		snprintf(filename, sizeof(filename), "%+03.0f%+04.0f-nrm.png",
+			floor(tile->lat / 10.0) * 10, floor(tile->lon / 10.0) * 10);
+		path = mkpathname(get_xpdir(), "Resources", "bitmaps",
+			"Earth Orbit Textures", filename, NULL);
+		png_pixels = png_load_from_file_rgba_auto(path,
+			&png_width, &png_height, &color_type, &bit_depth);
+		lacf_free(path);
+	}
+
 	if (png_pixels == NULL)
 		return (B_FALSE);
 	if (png_width < 1024 || png_height < 1024) {
@@ -553,18 +568,39 @@ load_earth_orbit_tex(dem_tile_t *tile, double load_res)
 			int png_y_hi = clamp(ceil(png_y), 0, png_height - 1);
 			double x_fract = png_x - png_x_lo;
 			double y_fract = png_y - png_y_lo;
-			uint8_t ul = png_pixels[sizeof (uint32_t) *
-			    (png_x_lo + png_y_lo * png_width) + 3];
-			uint8_t ur = png_pixels[sizeof (uint32_t) *
-			    (png_x_hi + png_y_lo * png_width) + 3];
-			uint8_t ll = png_pixels[sizeof (uint32_t) *
-			    (png_x_lo + png_y_hi * png_width) + 3];
-			uint8_t lr = png_pixels[sizeof (uint32_t) *
-			    (png_x_hi + png_y_hi * png_width) + 3];
-			double raw_val = wavg(wavg(ul, ur, x_fract),
-			    wavg(ll, lr, x_fract), y_fract);
-			double elev = fx_lin(raw_val, 0, EOT_ELEV_MAX,
-			    255, EOT_ELEV_MIN);
+			double elev;
+
+			/* If the elev file was used or not. */
+			if (ele_file) {
+				/* Only need to get any of the channels other 
+				 * than Alpha as all channels scale up the same!
+				*/
+				uint8_t ul = png_pixels[sizeof(uint32_t) *
+					(png_x_lo + png_y_lo * png_width) + 1];
+				uint8_t ur = png_pixels[sizeof(uint32_t) *
+					(png_x_hi + png_y_lo * png_width) + 1];
+				uint8_t ll = png_pixels[sizeof(uint32_t) *
+					(png_x_lo + png_y_hi * png_width) + 1];
+				uint8_t lr = png_pixels[sizeof(uint32_t) *
+					(png_x_hi + png_y_hi * png_width) + 1];
+				double raw_val = wavg(wavg(ul, ur, x_fract),
+					wavg(ll, lr, x_fract), y_fract);
+				elev = fx_lin(raw_val, 0, EOT_ELEV_MAX,
+					255, EOT_ELEV_MIN);
+			} else {
+				uint8_t ul = png_pixels[sizeof(uint32_t) *
+					(png_x_lo + png_y_lo * png_width) + 3];
+				uint8_t ur = png_pixels[sizeof(uint32_t) *
+					(png_x_hi + png_y_lo * png_width) + 3];
+				uint8_t ll = png_pixels[sizeof(uint32_t) *
+					(png_x_lo + png_y_hi * png_width) + 3];
+				uint8_t lr = png_pixels[sizeof(uint32_t) *
+					(png_x_hi + png_y_hi * png_width) + 3];
+				double raw_val = wavg(wavg(ul, ur, x_fract),
+					wavg(ll, lr, x_fract), y_fract);
+				elev = fx_lin(raw_val, 0, EOT_ELEV_MAX,
+					255, EOT_ELEV_MIN);
+			}
 
 			pixels[x + (pix_height - y - 1) * pix_width] =
 			    ELEV_WRITE(elev);


### PR DESCRIPTION
Using Earth Orbit Textures as a fallback for when there's no .dsf data was broken in X-Plane 12 as they changed what data is in the -nml files. The original code was using the Alpha channel to determine the elevation of a set of pixels.

This no longer works in X-Plane 12, as they now use dedicated -ele files that contain the same data, just not using the Alpha channel. Instead I have used the G channel. Since all three RGB have the same values any of them can be used. Just not Alpha!

The code tries to read the -ele file first, if that fails it resorts back to the old method so this will still work in X-Plane 11.